### PR TITLE
feat: check for address

### DIFF
--- a/src/components/SensitiveFieldsFinder/SensitiveFieldsFinder.tsx
+++ b/src/components/SensitiveFieldsFinder/SensitiveFieldsFinder.tsx
@@ -1,7 +1,7 @@
 import { Data } from "../shared";
 
 export const findAllSensitiveFields: any = (document: Data[]) => {
-  const paths = ["nric", "email", "email_address", "phone", "phone_number"];
+  const paths = ["nric", "email", "email_address", "phone", "phone_number", "address"];
   const sensitiveFields = [] as Data[];
 
   document.forEach((data) => {


### PR DESCRIPTION
From https://github.com/Open-Attestation/privacy-filter/issues/12, I noticed that residential address is not being checked, this MR fixes that and recommends filtering out a user's residential address.

Reason being residential address is considered personal data under PDPA (https://www.pdpc.gov.sg/-/media/Files/PDPC/PDF-Files/Resource-for-Individuals/what-you-need-to-know-about-pdpa-v1-0.pdf).

Note: While I know https://github.com/Open-Attestation/privacy-filter/issues/12 highlights a different issue as the current algorithm detects `nric` in key names, will probably change it to match NRIC using regex at a later stage.
